### PR TITLE
Add waitForElementUntilIsNotPresent() method

### DIFF
--- a/SeleniumClient/WebDriver.php
+++ b/SeleniumClient/WebDriver.php
@@ -409,6 +409,27 @@ class WebDriver
 
 		return $dynamicElement;
 	}
+
+	/**
+	 * Stops the process until an element is not found
+	 * @param By $locator
+	 * @param Integer $timeOutSeconds
+	 * @return boolean true when element is gone, false if element is still there
+	 */
+	public function waitForElementUntilIsNotPresent(By $locator, $timeOutSeconds = 5)
+	{
+		for ($second = 0; ; $second++)
+		{
+			if ($second >= $timeOutSeconds) return false;
+			$result = ($this->findElement($locator, true) === null);
+			if ($result)
+			{
+				return true;
+			}
+			sleep(1);
+		}
+	}
+
 	#endregion
 
 	#region WebElement Related


### PR DESCRIPTION
I needed a method to wait until an element was no longer present on the page. (Needed for detecting the closing of a modal iframe window in Joomla CMS.) I'm not sure I did this the best way. I tried catching the element not found exception, but that didn't seem to work. It appears that if you set the $pooling arg to true, you get a null result instead of an exception. So that is how I did this.

I don't know if you are interested in adding this to the base package. I didn't write a unit test for it. I don't think there is currently a unit test for waitForElementUntilIsPresent(), although it is used in some other unit tests.

In any case, thanks for the great package!
