### PR TITLE
Fix problem where selectByValue does not work for strings 

### DIFF
--- a/SeleniumClient/SelectElement.php
+++ b/SeleniumClient/SelectElement.php
@@ -42,7 +42,7 @@ class SelectElement
 	 */
 	public function selectByValue($value)
 	{
-		$options = $this->_element->findElements(By::xPath(".//option[@value = " . $value . "]"));
+		$options = $this->_element->findElements(By::xPath(".//option[@value = '" . $value . "']"));
 		
 		$matched = false;
 		foreach($options as $option)

--- a/SeleniumClientTest/Tests/SelectElementTest.php
+++ b/SeleniumClientTest/Tests/SelectElementTest.php
@@ -29,6 +29,12 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		$select->selectByValue("2");
 
 		$this->assertTrue($select->getElement()->findElement(By::xPath("option[@value = 2]"))->isSelected());
+
+		$select = new SelectElement($this->_driver->findElement(By::id("sel2")));
+
+		$select->selectByValue("onions");
+
+		$this->assertTrue($select->getElement()->findElement(By::xPath("option[@value = 'onions']"))->isSelected());
 	}
 }
 	


### PR DESCRIPTION
This change fixes a problem where select by value does not work for string values. Quotes are missing in xpath. I added a second case in the unit test to show this. 
