### PR TITLE
Add selectByPartialText method to SelectElement, with new unit test.

### DIFF
--- a/SeleniumClient/SelectElement.php
+++ b/SeleniumClient/SelectElement.php
@@ -61,4 +61,31 @@ class SelectElement
 			throw new \Exception("Cannot locate option in select element with value: " . $value);
 		}
 	}
+
+	/**
+	 * Sets an option selected by a partial text match
+	 * @param String $text
+	 * @throws \Exception
+	 */
+	public function selectByPartialText($text)
+	{
+		$options = $this->_element->findElements(By::xPath(".//option[contains(text(), '" . $text . "')]"));
+
+		$matched = false;
+		foreach($options as $option)
+		{
+
+			if(!$option->isSelected())
+			{
+				$option->click();
+			}
+
+			$matched = true;
+		}
+
+		if (!$matched)
+		{
+			throw new \Exception("Cannot locate option in select element with text: " . $text);
+		}
+	}
 }

--- a/SeleniumClientTest/Tests/SelectElementTest.php
+++ b/SeleniumClientTest/Tests/SelectElementTest.php
@@ -20,7 +20,7 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		if($this->_driver != null) { $this->_driver->quit(); }
 	}
 	
-	public function testSelectByValudShouldSelect()
+	public function testSelectByValueShouldSelect()
 	{
 		$this->_driver->get($this->_url);
 		
@@ -35,6 +35,23 @@ class SelectTest extends PHPUnit_Framework_TestCase
 		$select->selectByValue("onions");
 
 		$this->assertTrue($select->getElement()->findElement(By::xPath("option[@value = 'onions']"))->isSelected());
+	}
+	
+	public function testSelectByPartialTextShouldSelect()
+	{
+		$this->_driver->get($this->_url);
+	
+		$select = new SelectElement($this->_driver->findElement(By::id("sel1")));
+	
+		$select->selectByPartialText("Red");
+	
+		$this->assertTrue($select->getElement()->findElement(By::xPath("option[@value = 2]"))->isSelected());
+	
+		$select = new SelectElement($this->_driver->findElement(By::id("sel2")));
+	
+		$select->selectByPartialText("peppers");
+	
+		$this->assertTrue($select->getElement()->findElement(By::xPath("option[@value = 'greenpeppers']"))->isSelected());
 	}
 }
 	


### PR DESCRIPTION
This method allows you to select an option from a select group based on a partial match of the option element's text. This is a nice compliment to the existing selectByValue method. I've included a unit test for the method. Thanks.
