### PR TITLE
add public getEnvironment() to allow for screenshots

### DIFF
--- a/SeleniumClient/WebDriver.php
+++ b/SeleniumClient/WebDriver.php
@@ -55,6 +55,14 @@ class WebDriver
 	public function setEnvironment($value) { $this->_environment = $value; }
 	
 	/**
+	 * Get current Selenium environment
+	 * @return String
+	 */
+	public function getEnvironment() {
+		return $this->_environment;
+	}
+
+	/**
 	 * Get current Selenium Hub url
 	 * @return String
 	 */


### PR DESCRIPTION
Add a public getEnvironment method to WebDriver to allow access to private property. This is needed to create screenshots from external classes. (The _environment property is used in the screenshot() method). Thanks!
