### PR TITLE
Repairs - waiting, encoding

### DIFF
--- a/SeleniumClient/WebDriver.php
+++ b/SeleniumClient/WebDriver.php
@@ -449,11 +449,29 @@ class WebDriver
 	public function webElementSendKeys($elementId, $text)
 	{
 		$command = "value";
-		$params = array('value' => str_split($text));
+		$params = array('value' => $this->getCharArray($text));
 		$urlHubFormatted = $this->_hubUrl . "/session/{$this->_sessionId}/element/{$elementId}/{$command}";
 		
 		$httpClient = HttpFactory::getClient($this->_environment);
 		$httpClient->setUrl($urlHubFormatted)->setHttpMethod(HttpClient::POST)->setJsonParams($params)->execute();
+	}
+	
+	/**
+	 * Returns array of chars from String
+	 * @param String $text
+	 * @return array
+	 */
+	private function getCharArray($text)
+	{
+		$encoding = \mb_detect_encoding($text);
+		$len = \mb_strlen($text, $encoding);
+		$ret = array();
+		while($len) {
+			$ret[] = \mb_substr($text, 0, 1, $encoding);
+			$text = \mb_substr($text, 1, $len, $encoding);
+			$len = \mb_strlen($text, $encoding);
+		}
+		return $ret;
 	}
 	
 	/**

--- a/SeleniumClient/WebDriverWait.php
+++ b/SeleniumClient/WebDriverWait.php
@@ -53,7 +53,11 @@ class WebDriverWait
 		
 		while ($wait)
 		{
-			$resultObject = call_user_func_array(array ($seleniumObject, $method), $args);
+			try {
+				$resultObject = call_user_func_array(array ($seleniumObject, $method), $args);
+			} catch (\Exception $ex) {
+
+			}
 			
 			if ($resultObject != null && $resultObject != false) { $wait = false; }
 			else


### PR DESCRIPTION
Repaired waiting for element (if not closed in try-catch - throwing \SeleniumClient\Http\SeleniumNoSuchElementException)

Repaired encoding (before repair cannot send multiple-byte-string to elements)
